### PR TITLE
bug fix more than one text/plain mime part

### DIFF
--- a/Class Library/ActiveUp.Net.Common/Parser.cs
+++ b/Class Library/ActiveUp.Net.Common/Parser.cs
@@ -190,7 +190,7 @@ namespace ActiveUp.Net.Mail
 
                 // We will consider the highest-level text parts that are not attachments to be the intended for display.
                 // We know the highest-level parts will be set, because the parser first goes to the deepest level and returns top-level parts last.
-                if (part.ContentType.Type.Equals("text") && !part.ContentDisposition.Disposition.Equals("attachment"))
+                if (part.ContentType.Type.Equals("text") && !part.ContentDisposition.Disposition.Equals("attachment") && !string.IsNullOrWhiteSpace(part.TextContent))
                 {
                     if (part.ContentType.SubType.Equals("plain"))
                     {


### PR DESCRIPTION
i had an issue where an email message had 2 text/plain mime parts. line 193 then executes on both of them.
in my case the 2nd mime part had no TextContent and it overwrote the correct BodyText.Text setting it to empty string.
I added a small fix to check if the TextContent part is not empty in the same if statement. Thanks!
